### PR TITLE
Hll upgrades 9/22

### DIFF
--- a/hll.go
+++ b/hll.go
@@ -15,6 +15,16 @@ const (
 	alpha_64 = 0.709
 )
 
+// In order to mitigate the computational expense of math.Pow,
+// we use a lookup table to calculate the harmonic mean of the values in the registers
+var lookupTable [256]float64
+
+func init() {
+	for i := 0; i < 256; i++ {
+		lookupTable[i] = math.Pow(2, float64(i))
+	}
+}
+
 type Hll struct {
 	bigM                normal   // M is used for the dense case, and registers the rho values for each hashed index.
 	sparseList          *sparse  // This will be nil if isSparse==false. Used for sparse case for aggregation
@@ -194,7 +204,7 @@ func (h *Hll) cardinalityNormal() uint64 {
 	// calculate the harmonic mean of the values in the registers.
 	for i := uint64(0); i < h.m; i++ {
 		registerVal := h.bigM.Get(i)
-		inverseSum += 1 / math.Pow(2, float64(registerVal))
+		inverseSum += 1 / lookupTable[registerVal]
 		if registerVal == 0 {
 			V++
 		}

--- a/hll.go
+++ b/hll.go
@@ -316,6 +316,15 @@ func (h *Hll) UnmarshalPb(buf []byte) error {
 	return nil
 }
 
+// custom gob encoder and decoders
+func (h *Hll) GobEncode() ([]byte, error) {
+	return h.MarshalJSON()
+}
+
+func (h *Hll) GobDecode(data []byte) error {
+	return h.UnmarshalJSON(data)
+}
+
 // Returns linear counting cardinality estimate.
 func linearCounting(m, v uint64) uint64 {
 	count := float64(m) * math.Log(float64(m)/float64(v))


### PR DESCRIPTION
 - replace `math.Pow()` with lookup table. This will decrease computational expense of Hll. 
 - add custom `gob` serializer and deserializer